### PR TITLE
AssetBundles are being removed when building APK (#4)

### DIFF
--- a/Editor/AssetPackBuilder.cs
+++ b/Editor/AssetPackBuilder.cs
@@ -119,5 +119,10 @@ namespace Khepri.PlayAssetDelivery.Editor
 			}
 			return config;
 		}
+
+		public static void ClearConfig()
+		{
+			AssetDatabase.DeleteAsset(AssetPackBundleConfig.PATH);
+		}
     }
 }

--- a/Editor/PlayAssetPackBundlesPreprocessor.cs
+++ b/Editor/PlayAssetPackBundlesPreprocessor.cs
@@ -12,18 +12,15 @@ public class PlayAssetPackBundlesPreprocessor : IPreprocessBuildWithReport
 
     public void OnPreprocessBuild(BuildReport report)
     {
-        if (report.summary.platform != BuildTarget.Android)
+        if (report.summary.platform != BuildTarget.Android || !Path.GetExtension(report.summary.outputPath).Equals("aab"))
         {
-            return;
-        }
-        if (!Path.GetExtension(report.summary.outputPath).Equals("aab"))
-        {
+            AssetPackBuilder.ClearConfig();
             return;
         }
         UDebug.Log($"[{nameof(PlayAssetPackBundlesPreprocessor)}.{nameof(OnPreprocessBuild)}]");
         foreach (var bundle in AssetPackBuilder.GetBundles(Addressables.PlayerBuildDataPath))
         {
             bundle.DeleteFile();
-        };
+        }
     }
 }

--- a/Editor/PlayAssetPackBundlesPreprocessor.cs
+++ b/Editor/PlayAssetPackBundlesPreprocessor.cs
@@ -1,4 +1,5 @@
-﻿using Khepri.PlayAssetDelivery.Editor;
+﻿using System.IO;
+using Khepri.PlayAssetDelivery.Editor;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
@@ -12,6 +13,10 @@ public class PlayAssetPackBundlesPreprocessor : IPreprocessBuildWithReport
     public void OnPreprocessBuild(BuildReport report)
     {
         if (report.summary.platform != BuildTarget.Android)
+        {
+            return;
+        }
+        if (!Path.GetExtension(report.summary.outputPath).Equals("aab"))
         {
             return;
         }


### PR DESCRIPTION
Fix for #4 

- [x] Check extension of output path.
- [x] Remove AssetPack runtime configuration when not building AAB
- [ ] Testing