### PR TITLE
Fix; handle.PercentComplate is always 0 when downloading remote packs

### DIFF
--- a/Editor/PlayAssetPackBundlesPreprocessor.cs
+++ b/Editor/PlayAssetPackBundlesPreprocessor.cs
@@ -37,6 +37,14 @@ public class PlayAssetPackBundlesPreprocessor : BuildPlayerProcessor
             UDebug.Log($"[{nameof(PlayAssetPackBundlesPreprocessor)}.{nameof(PrepareForBuild)}] No bundles removed.");
             return;
         }
+        
+#if PAD_DELETE_BUNDLE_POST_BUILD
+        DeleteBundles(bundles);
+#endif
+    }
+
+    void DeleteBundles(AssetPackBundle[] bundles)
+    {
         foreach (var bundle in bundles)
         {
             bundle.DeleteFile();

--- a/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
+++ b/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
@@ -40,12 +40,18 @@ namespace Khepri.AssetDelivery.ResourceHandlers
 #if !UNITY_2019_3_OR_NEWER
             webRequest.chunkedTransfer = Options.ChunkedTransfer;
 #endif
+            m_ProvideHandle.SetProgressCallback(()=> GetDownloadProgress(webRequest));
             if (m_ProvideHandle.ResourceManager.CertificateHandlerInstance != null)
             {
                 webRequest.certificateHandler = m_ProvideHandle.ResourceManager.CertificateHandlerInstance;
                 webRequest.disposeCertificateHandlerOnDispose = false;
             }
             return webRequest;
+        }
+
+        float GetDownloadProgress(UnityWebRequest webRequest)
+        {
+            return webRequest.isDone ? 1f : webRequest.downloadProgress;
         }
 
         protected void WebRequestOperationCompleted(AsyncOperation op)

--- a/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
+++ b/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
@@ -8,6 +8,7 @@ namespace Khepri.AssetDelivery.ResourceHandlers
     public abstract class WebRequestAssetBundleResourceHandlerBase : AssetBundleResourceHandlerBase
     {
         private int m_retries;
+        private UnityWebRequest webRequest;
 
         protected override bool IsValidPath(string path)
         {
@@ -29,7 +30,7 @@ namespace Khepri.AssetDelivery.ResourceHandlers
             if (Options == null)
                 return UnityWebRequestAssetBundle.GetAssetBundle(url);
 
-            var webRequest = !string.IsNullOrEmpty(Options.Hash) ?
+            webRequest = !string.IsNullOrEmpty(Options.Hash) ?
                 UnityWebRequestAssetBundle.GetAssetBundle(url, Hash128.Parse(Options.Hash), Options.Crc) :
                 UnityWebRequestAssetBundle.GetAssetBundle(url, Options.Crc);
 

--- a/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
+++ b/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
@@ -53,8 +53,13 @@ namespace Khepri.AssetDelivery.ResourceHandlers
         {
             if (webRequest == null)
                 return 0;
-                
+
             return webRequest.isDone ? 1f : webRequest.downloadProgress;
+        }
+
+        protected void SetWebRequest(UnityWebRequest request)
+        {
+            webRequest = request;
         }
 
         protected void WebRequestOperationCompleted(AsyncOperation op)

--- a/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
+++ b/Runtime/ResourceHandlers/WebRequestAssetBundleResourceHandlerBase.cs
@@ -40,7 +40,6 @@ namespace Khepri.AssetDelivery.ResourceHandlers
 #if !UNITY_2019_3_OR_NEWER
             webRequest.chunkedTransfer = Options.ChunkedTransfer;
 #endif
-            m_ProvideHandle.SetProgressCallback(()=> GetDownloadProgress(webRequest));
             if (m_ProvideHandle.ResourceManager.CertificateHandlerInstance != null)
             {
                 webRequest.certificateHandler = m_ProvideHandle.ResourceManager.CertificateHandlerInstance;
@@ -49,8 +48,11 @@ namespace Khepri.AssetDelivery.ResourceHandlers
             return webRequest;
         }
 
-        float GetDownloadProgress(UnityWebRequest webRequest)
+        protected override float PercentComplete()
         {
+            if (webRequest == null)
+                return 0;
+                
             return webRequest.isDone ? 1f : webRequest.downloadProgress;
         }
 

--- a/Runtime/ResourceHandlers/WebRequestAsyncAssetBundleResourceHandler.cs
+++ b/Runtime/ResourceHandlers/WebRequestAsyncAssetBundleResourceHandler.cs
@@ -19,6 +19,7 @@ namespace Khepri.AssetDelivery.ResourceHandlers
 
         private void OnQueueOperationCompleted(UnityWebRequestAsyncOperation asyncOp)
         {
+            SetWebRequest(asyncOp.webRequest);
             m_RequestOperation = asyncOp;
             if (m_RequestOperation.isDone)
             {


### PR DESCRIPTION
Fixed the issue where getting handle.PercentComplete always return 0 when downloading remote packs such as Fast-Follow or On-Demand packs by setting Progress Callback to m_ProvideHandle in WebRequestAssetBundleResourceHandlerBase.