### PR TITLE
Fix AssetPack creation (On demand and Fast follow) for the latest Goo…

### DIFF
--- a/Editor/Settings/GroupSchemas/AssetPackGroupSchema.cs
+++ b/Editor/Settings/GroupSchemas/AssetPackGroupSchema.cs
@@ -21,9 +21,9 @@ namespace Khepri.PlayAssetDelivery.Editor.Settings.GroupSchemas
             return new AssetPack
             {
                 DeliveryMode = m_DeliveryMode,
-                CompressionFormatToAssetPackDirectoryPath = new Dictionary<TextureCompressionFormat, string>()
+                CompressionFormatToAssetBundleFilePath = new Dictionary<TextureCompressionFormat, string>()
                 {
-                    {textureCompressionFormat, Path.GetDirectoryName(bundle)}
+                    {textureCompressionFormat, bundle}
                 }
             };
         }


### PR DESCRIPTION
PAD Bundles are not added for Google Android App Bundle version 1.9.0 due to filtering (path.TextureCompressionFormat != TextureCompressionFormat.Default) in the following code:

Method Google.Android.AppBundle.Editor.Internal.Config.SerializationHelper.Deserialize()

![image](https://github.com/jelte/be.khepri.play.assetdelivery.addressables/assets/1681699/d1c3cd3a-e554-491e-b84d-0b1f3745c871)
